### PR TITLE
マッチング修正(不安定な恐れあり)

### DIFF
--- a/Assets/CardSortingGame/Scripts/ItemUsingManager.cs
+++ b/Assets/CardSortingGame/Scripts/ItemUsingManager.cs
@@ -30,7 +30,6 @@ public class ItemUsingManager : MonoBehaviour
             ApplyItemEffect(item);
         }*/
 
-
     }
 
     private void ApplyItemEffect(int itemIdx)

--- a/Assets/Resources.meta
+++ b/Assets/Resources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 458f716b504174972955b7f83cad5c68
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/UnityPlayerAccountSettings.asset
+++ b/Assets/Resources/UnityPlayerAccountSettings.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b58a3bc647e70774b8c7225eb3b51e7e, type: 3}
+  m_Name: UnityPlayerAccountSettings
+  m_EditorClassIdentifier: 
+  clientId: 
+  scopeMask: 7
+  useCustomDeepLinkUri: 0
+  customScheme: 
+  customHost: 

--- a/Assets/Resources/UnityPlayerAccountSettings.asset.meta
+++ b/Assets/Resources/UnityPlayerAccountSettings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8ea5e65fbab6f40d9a6ae303201ba767
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/CardSortingGame.unity
+++ b/Assets/Scenes/CardSortingGame.unity
@@ -3804,7 +3804,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6960e84d07fb87f47956e7a81d71c4e6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_ProtocolType: 0
+  m_ProtocolType: 1
   m_UseWebSockets: 1
   m_UseEncryption: 0
   m_MaxPacketQueueSize: 128

--- a/Assets/Scenes/ChooseServerSoA.unity
+++ b/Assets/Scenes/ChooseServerSoA.unity
@@ -495,6 +495,105 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 443039192}
   m_CullTransparentMesh: 1
+--- !u!1 &481913338
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 481913341}
+  - component: {fileID: 481913340}
+  - component: {fileID: 481913339}
+  m_Layer: 0
+  m_Name: NetworkManager (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &481913339
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 481913338}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6960e84d07fb87f47956e7a81d71c4e6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ProtocolType: 1
+  m_UseWebSockets: 1
+  m_UseEncryption: 0
+  m_MaxPacketQueueSize: 128
+  m_MaxPayloadSize: 6144
+  m_HeartbeatTimeoutMS: 500
+  m_ConnectTimeoutMS: 1000
+  m_MaxConnectAttempts: 60
+  m_DisconnectTimeoutMS: 30000
+  ConnectionData:
+    Address: 127.0.0.1
+    Port: 7777
+    ServerListenAddress: 127.0.0.1
+  DebugSimulator:
+    PacketDelayMS: 0
+    PacketJitterMS: 0
+    PacketDropRate: 0
+--- !u!114 &481913340
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 481913338}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 593a2fe42fa9d37498c96f9a383b6521, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  NetworkConfig:
+    ProtocolVersion: 0
+    NetworkTransport: {fileID: 481913339}
+    PlayerPrefab: {fileID: 0}
+    Prefabs:
+      NetworkPrefabsLists:
+      - {fileID: 11400000, guid: 8c8e984e549074293ac251cac3d26d9a, type: 2}
+    TickRate: 30
+    ClientConnectionBufferTimeout: 10
+    ConnectionApproval: 0
+    ConnectionData: 
+    EnableTimeResync: 0
+    TimeResyncInterval: 30
+    EnsureNetworkVariableLengthSafety: 0
+    EnableSceneManagement: 1
+    ForceSamePrefabs: 1
+    RecycleNetworkIds: 1
+    NetworkIdRecycleDelay: 120
+    RpcHashSize: 0
+    LoadSceneTimeOut: 120
+    SpawnTimeout: 10
+    EnableNetworkLogs: 1
+    OldPrefabList: []
+  RunInBackground: 1
+  LogLevel: 0
+--- !u!4 &481913341
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 481913338}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -2.94, y: 9, z: 0.0056424662}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &687183970
 GameObject:
   m_ObjectHideFlags: 0
@@ -1554,105 +1653,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1561328534}
   m_CullTransparentMesh: 1
---- !u!1 &1619151284
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1619151287}
-  - component: {fileID: 1619151286}
-  - component: {fileID: 1619151285}
-  m_Layer: 0
-  m_Name: NetworkManager
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &1619151285
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1619151284}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6960e84d07fb87f47956e7a81d71c4e6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_ProtocolType: 1
-  m_UseWebSockets: 1
-  m_UseEncryption: 0
-  m_MaxPacketQueueSize: 128
-  m_MaxPayloadSize: 6144
-  m_HeartbeatTimeoutMS: 500
-  m_ConnectTimeoutMS: 1000
-  m_MaxConnectAttempts: 60
-  m_DisconnectTimeoutMS: 30000
-  ConnectionData:
-    Address: 127.0.0.1
-    Port: 7777
-    ServerListenAddress: 127.0.0.1
-  DebugSimulator:
-    PacketDelayMS: 0
-    PacketJitterMS: 0
-    PacketDropRate: 0
---- !u!114 &1619151286
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1619151284}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 593a2fe42fa9d37498c96f9a383b6521, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  NetworkConfig:
-    ProtocolVersion: 0
-    NetworkTransport: {fileID: 1619151285}
-    PlayerPrefab: {fileID: 0}
-    Prefabs:
-      NetworkPrefabsLists:
-      - {fileID: 11400000, guid: 8c8e984e549074293ac251cac3d26d9a, type: 2}
-    TickRate: 30
-    ClientConnectionBufferTimeout: 10
-    ConnectionApproval: 1
-    ConnectionData: 
-    EnableTimeResync: 0
-    TimeResyncInterval: 30
-    EnsureNetworkVariableLengthSafety: 0
-    EnableSceneManagement: 1
-    ForceSamePrefabs: 1
-    RecycleNetworkIds: 1
-    NetworkIdRecycleDelay: 120
-    RpcHashSize: 0
-    LoadSceneTimeOut: 120
-    SpawnTimeout: 10
-    EnableNetworkLogs: 1
-    OldPrefabList: []
-  RunInBackground: 1
-  LogLevel: 0
---- !u!4 &1619151287
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1619151284}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -2.94, y: 9, z: 0.0056424662}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1982741334
 GameObject:
   m_ObjectHideFlags: 0
@@ -1713,4 +1713,4 @@ SceneRoots:
   - {fileID: 1186468157}
   - {fileID: 687183974}
   - {fileID: 402125723}
-  - {fileID: 1619151287}
+  - {fileID: 481913341}

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -5,7 +5,7 @@
     "com.unity.ide.rider": "3.0.28",
     "com.unity.ide.visualstudio": "2.0.22",
     "com.unity.multiplayer.samples.coop": "https://github.com/Unity-Technologies/com.unity.multiplayer.samples.coop.git?path=/Packages/com.unity.multiplayer.samples.coop#main",
-    "com.unity.netcode.gameobjects": "1.8.1",
+    "com.unity.services.authentication": "3.3.3",
     "com.unity.services.relay": "1.1.1",
     "com.unity.test-framework": "1.1.33",
     "com.unity.textmeshpro": "3.0.6",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -214,7 +214,7 @@
     },
     "com.unity.netcode.gameobjects": {
       "version": "1.8.1",
-      "depth": 0,
+      "depth": 1,
       "source": "registry",
       "dependencies": {
         "com.unity.transport": "1.4.0",
@@ -224,7 +224,7 @@
     },
     "com.unity.nuget.mono-cecil": {
       "version": "1.11.4",
-      "depth": 1,
+      "depth": 2,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"
@@ -244,19 +244,19 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.services.authentication": {
-      "version": "2.7.4",
-      "depth": 1,
+      "version": "3.3.3",
+      "depth": 0,
       "source": "registry",
       "dependencies": {
         "com.unity.ugui": "1.0.0",
-        "com.unity.services.core": "1.12.5",
+        "com.unity.services.core": "1.13.0",
         "com.unity.nuget.newtonsoft-json": "3.2.1",
         "com.unity.modules.unitywebrequest": "1.0.0"
       },
       "url": "https://packages.unity.com"
     },
     "com.unity.services.core": {
-      "version": "1.12.5",
+      "version": "1.13.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {

--- a/ProjectSettings/Packages/com.unity.services.core/Settings.json
+++ b/ProjectSettings/Packages/com.unity.services.core/Settings.json
@@ -1,0 +1,1 @@
+{"EnvironmentName":""}


### PR DESCRIPTION
CardSortingGameのシーンにあるnetworkmanagerをChooseServerSoAのシーンにコピペして置き換えたらなぜか正常に動作するようになった(callbackも機能している) startclientした後に「connected」と出ればhostと正式に接続できたと言えるところまでは把握でき、今までcallbackが出ないなどの不備があったのは純粋に「startclientしたのまではいいけどそこからhostに繋がるまでが上手くいかなかった」のがcallbackが出なかった原因と思われる(callbackが来なくなってた時期はconnectedというログが返ってこなかったため、接続してるのにcallbackが来ていないというのは勘違いで、そもそも接続ができてなかった)ただそれを踏まえたとしてもnetworkmanagerを置き換えただけでなんか上手くいくようになったというもので、原因究明にはまるで至っていない(ただ、匿名サインイン時にホストとクライアントで同じIDであることは問題ではなさそう) これにしても404 not foundエラーはやはり確率で発生するままだが、今までとは異なってホスト側でもエラーが出る(3つぐらいエラーが出て、4つ目のエラーでホストのサーバーが強制停止される)ようになったので、このエラー内容群から404 not foundが出る原因の究明ができそう。以下はそのエラーの一覧

Received error message from Relay: player timed out due to inactivity.

リレーから送られたエラーメッセージで、プレイヤーが非アクティブであるためタイムアウトしたという旨の説明がされている

Relay allocation is invalid. See NetworkDriver.GetRelayConnectionStatus and RelayConnectionStatus.AllocationInvalid for details on how to handle this situation.

リレー割り当て(立てた部屋)が無効であるというエラー。その次の文からは対処方法としてNetworkDriver.GetRelayConnectionStatusおよびRelayConnectionStatus.AllocationInvalidを参照しろと催促している

Transport failure! Relay allocation needs to be recreated, and NetworkManager restarted. Use NetworkManager.OnTransportFailure to be notified of such events programmatically.

トランスポートが失敗(?)し、部屋の再生成、networkmanagerの再起動をしろという旨のエラー。

[Netcode] Host is shutting down due to network transport failure of UnityTransport!

unitytransportの障害によって、ホストがシャットダウンしているという旨のエラー(というより警告) このエラーの後ホストが強制的にシャットダウンされた。

ちなみに、ここまでの過程で、新たにpackage managerから「Authentication」のパッケージを最新版にアップデートした(匿名サインインなどの機能を司るもの)ので、もしこれをpullしても上手くいかなかった場合はパッケージのバージョンが同じか確認した方がいいかもしれない