### PR TITLE
joincode修正+UIの改善

### DIFF
--- a/Assets/CardSortingGame/Scripts/InformationManager.cs
+++ b/Assets/CardSortingGame/Scripts/InformationManager.cs
@@ -5,6 +5,7 @@ using TMPro;
 public class InformationManager : MonoBehaviour
 {
     public TextMeshProUGUI informationText;
+    public string questionResult = "";
     void Start()
     {
         informationText = this.GetComponent<TextMeshProUGUI>();
@@ -14,11 +15,15 @@ public class InformationManager : MonoBehaviour
     public void SetInformationText(string str)
     {
         informationText.text = str;
-
     }
 
     public void ClearInformationText()
     {
         informationText.text = "";
+    }
+
+    public void ShowQuestionResult()
+    {
+        SetInformationText(questionResult);
     }
 }

--- a/Assets/CardSortingGame/Scripts/ItemUsingManager.cs
+++ b/Assets/CardSortingGame/Scripts/ItemUsingManager.cs
@@ -153,6 +153,7 @@ public class ItemUsingManager : MonoBehaviour
         if(otherlist.Contains(3)){
             //もし相手がアイテム4を持っていたら、質問不可能bool値をtrueにする。
             networkSystem.questionController.isNotQuestion=true;
+            networkSystem.informationManager.SetInformationText("相手のアイテム効果により質問できません!");
         }
     }
 

--- a/Assets/CardSortingGame/Scripts/MobileKeyboardFix.cs
+++ b/Assets/CardSortingGame/Scripts/MobileKeyboardFix.cs
@@ -1,0 +1,25 @@
+using UnityEngine;
+using TMPro;
+
+public class MobileKeyboardFix : MonoBehaviour
+{
+    private TMP_InputField inputField;
+    private TouchScreenKeyboard keyboard;
+
+    void Start()
+    {
+        inputField = GetComponent<TMP_InputField>();
+        
+        // TextMeshProのイベントリスナーに独自のフォーカスハンドラーを追加
+        inputField.onSelect.AddListener(OpenKeyboardOnMobile);
+    }
+
+    void OpenKeyboardOnMobile(string text)
+    {
+        if (Application.isMobilePlatform)
+        {
+            // スマートフォンの場合、キーボードを開く
+            keyboard = TouchScreenKeyboard.Open(inputField.text, TouchScreenKeyboardType.Default);
+        }
+    }
+}

--- a/Assets/CardSortingGame/Scripts/MobileKeyboardFix.cs.meta
+++ b/Assets/CardSortingGame/Scripts/MobileKeyboardFix.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e77aed9973464431bbaaffebb95c68d7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/CardSortingGame/Scripts/NetworkSystem.cs
+++ b/Assets/CardSortingGame/Scripts/NetworkSystem.cs
@@ -466,6 +466,7 @@ public class NetworkSystem : NetworkBehaviour
             if (hostAttacked)
             {
                 Debug.Log("攻撃失敗！");
+                Log("攻撃失敗！");
                 informationManager.SetInformationText("攻撃失敗！");
             }
             if (clientAttacked)SetInformationTextClientRpc("攻撃失敗！");

--- a/Assets/CardSortingGame/Scripts/PhaseManager.cs
+++ b/Assets/CardSortingGame/Scripts/PhaseManager.cs
@@ -50,6 +50,7 @@ public class PhaseManager : MonoBehaviour
         switch (newPhase)
         {
             case InitialPhase:
+                networkSystem.informationManager.ShowQuestionResult();
                 AttackAction();
                 break;
 

--- a/Assets/CardSortingGame/Scripts/QutstionController.cs
+++ b/Assets/CardSortingGame/Scripts/QutstionController.cs
@@ -7,6 +7,7 @@ using UnityEngine.UI;
 using UnityEngine.SceneManagement;
 using System.Linq;
 using Unity.VisualScripting;
+using TMPro;
 
 public class QutstionController : MonoBehaviour
 {
@@ -30,6 +31,8 @@ public class QutstionController : MonoBehaviour
     public bool isThreeSelect = false;
     public bool isNotQuestion = false;
     
+    private TextMeshProUGUI instruction;
+
     void Start()
     {
         cardsManager = FindObjectOfType<CardsManager>();
@@ -37,6 +40,7 @@ public class QutstionController : MonoBehaviour
         
         questionBG = GameObject.Find("QuestioningBG");
         cardPanel = GameObject.Find("QuestionCardPanel").transform;
+        instruction = GameObject.Find("Text").GetComponent<TextMeshProUGUI>(); // 案内テキストを取得
         questionBG.SetActive(false);// 非表示
         originalBGColor = questionBG.GetComponent<Image>().color;
         
@@ -47,6 +51,7 @@ public class QutstionController : MonoBehaviour
 
     public void StartQuestionPhase()
     {
+        instruction.text = isThreeSelect ? "カードを3枚選んでください" : "カードを2枚選んでください"; // 案内テキストの中身を変更
         if(!isNotQuestion){
             questionBG.SetActive(true);
             questionBG.GetComponent<Image>().color = originalBGColor; // 背面色の変更
@@ -196,13 +201,13 @@ public class QutstionController : MonoBehaviour
         
         string leftName = leftCard.name, rightName = rightCard.name;
         Debug.Log("left:"+leftName + " right:"+rightName);
-        networkSystem.Log(leftName + "と"+rightName + "を比較しました");
 
         //ここの処理の補足
         //これで得られるのは数値ではなく、厳密には「先頭文字を文字コードで表したときの数値」
         //文字コード表では基本的に1から9の順に文字コードの数値も大きくなるので、一応これでも成立する
-        if(leftName[leftName.Length - 1] < rightName[rightName.Length - 1]) Debug.Log("right card is greater");
-        else Debug.Log("left card is greater");
+        string informationText = "";
+        if(leftName[leftName.Length - 1] < rightName[rightName.Length - 1]) informationText = "右のカードの方が大きい\n";
+        else informationText = "左のカードの方が大きい\n";
         
         if(isGetDiff){
             //アイテム2の処理
@@ -211,9 +216,12 @@ public class QutstionController : MonoBehaviour
 
             Debug.Log("カードの差は"+Diff.ToString()+"です");
             networkSystem.Log("カードの差は"+Diff.ToString()+"です");
+            informationText = informationText + "カードの差は" + Diff.ToString() + "です";
 
             isGetDiff=false;
         }
+        networkSystem.informationManager.questionResult = informationText;
+        networkSystem.Log(informationText);
         return 0;
     }
 
@@ -270,6 +278,7 @@ public class QutstionController : MonoBehaviour
 
         Debug.Log("Left:"+left+" middle:"+middle+" right:"+right);
         networkSystem.Log("左:"+left+" 中:"+middle+" 右:"+right);
+        networkSystem.informationManager.questionResult = "左:"+left+" 中:"+middle+" 右:"+right;
         return 0;
     }
 }

--- a/Assets/Scenes/ChooseServerSoA.unity
+++ b/Assets/Scenes/ChooseServerSoA.unity
@@ -1029,8 +1029,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 28
-  m_fontSizeBase: 28
+  m_fontSize: 24
+  m_fontSizeBase: 24
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
@@ -1357,10 +1357,10 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Enter JoinCode...
+  m_text: "JoinCode\u3092\u5165\u529B"
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 3f9508a64a5d04eb7aab767b58288ae5, type: 2}
+  m_sharedMaterial: {fileID: 8491621916487589897, guid: 3f9508a64a5d04eb7aab767b58288ae5, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -1384,8 +1384,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 28
-  m_fontSizeBase: 28
+  m_fontSize: 24
+  m_fontSizeBase: 24
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
@@ -1613,6 +1613,7 @@ GameObject:
   - component: {fileID: 1561328538}
   - component: {fileID: 1561328537}
   - component: {fileID: 1561328536}
+  - component: {fileID: 1561328539}
   m_Layer: 5
   m_Name: InputText
   m_TagString: Untagged
@@ -1688,16 +1689,16 @@ MonoBehaviour:
   m_VerticalScrollbarEventHandler: {fileID: 0}
   m_LayoutGroup: {fileID: 0}
   m_ScrollSensitivity: 1
-  m_ContentType: 0
+  m_ContentType: 9
   m_InputType: 0
   m_AsteriskChar: 42
-  m_KeyboardType: 0
+  m_KeyboardType: 1
   m_LineType: 0
   m_HideMobileInput: 0
   m_HideSoftKeyboard: 0
   m_CharacterValidation: 0
   m_RegexValue: 
-  m_GlobalPointSize: 14
+  m_GlobalPointSize: 24
   m_CharacterLimit: 0
   m_OnEndEdit:
     m_PersistentCalls:
@@ -1788,6 +1789,18 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1561328534}
   m_CullTransparentMesh: 1
+--- !u!114 &1561328539
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1561328534}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e77aed9973464431bbaaffebb95c68d7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1982741334
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/SoAPhaseScenes/QuestionPhase.unity
+++ b/Assets/Scenes/SoAPhaseScenes/QuestionPhase.unity
@@ -456,6 +456,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 358527081}
     m_Modifications:
+    - target: {fileID: 65383276005178563, guid: 89ae0cdfc7df548b3964f552be417ba0, type: 3}
+      propertyPath: m_Name
+      value: Text
+      objectReference: {fileID: 0}
     - target: {fileID: 646091648773616959, guid: 89ae0cdfc7df548b3964f552be417ba0, type: 3}
       propertyPath: m_SizeDelta.x
       value: 189.9335


### PR DESCRIPTION
# 変更点
* モバイル端末でもJoinCodeの入力ができるはず。~~(Dockerの問題でまだテストできてない)~~
* アイテム5を使った時も「カードを2枚選択してください」のままだったので、それを改善
* カードの比較結果が表示されるようにした

# さらに追加する仕様
1. ~~アイテム6を使う時もスマホ入力できるようにする。(和田)~~
2. アイテム選択画面で、ボタンをアイテムのロゴにする
3. フェーズのロゴを表示 (野口)
4. カードの並び替えのアニメーションを変える。(田村)
5. 準備中、準備完了のアイコンを実装(田村)
6. ~~自分が準備できたら「相手を待っています」を表示 (和田)~~
7. 相手のカードの数字は見えるようにする
8. ~~攻撃をログに残す (和田)~~
9. ログのスクロールがきもいので直す (和田)
10. ~~相手が攻撃を失敗したことも出す(和田)~~
11. 質問画面で、カードを選んだら色を変えるのではなく、少し上にずらす
12. カード3枚比較のとき、結果の表示を変える(今は"漢:aaa"のようになっている)←これはデザイン班にも相談
13. アイテムの見た目を新しい方にする
14. 質問が封じられたことを表示(アイテム4)

思いついたので追加: JoinCodeの入力でエラーが出た時、アプリが止まらないようにする

# バグ報告
### ~~ホスト側がアイテムを何も使用せず、クライアント側がアイテム3を使用。両者が決定ボタンを押し終わった直後、ホスト側のコンソールに以下のようなエラーが出た。~~
~~ArgumentOutOfRangeException: Index was out of range. Must be non-negative and less than the size of the collection.
Parameter name: index
System.Collections.Generic.List`1[T].get_Item (System.Int32 index) (at <e307bbb467104258887a104f6151f183>:0)
ItemUsingManager.ItemThreeCheckAndUse () (at Assets/CardSortingGame/Scripts/ItemUsingManager.cs:206)
ItemUsingManager+<StartItemUsePhaseIEnumerator>d__23.MoveNext () (at Assets/CardSortingGame/Scripts/ItemUsingManager.cs:116)
UnityEngine.SetupCoroutine.InvokeMoveNext (System.Collections.IEnumerator enumerator, System.IntPtr returnValueAddress) (at /Users/bokken/build/output/unity/unity/Runtime/Export/Scripting/Coroutines.cs:17)
UnityEngine.MonoBehaviour:StartCoroutine(IEnumerator)
ItemUsingManager:StartItemUsePhase() (at Assets/CardSortingGame/Scripts/ItemUsingManager.cs:89)
<HandlePhaseChangeIEnumerator>d__7:MoveNext() (at Assets/CardSortingGame/Scripts/PhaseManager.cs:66)
UnityEngine.SetupCoroutine:InvokeMoveNext(IEnumerator, IntPtr) (at /Users/bokken/build/output/unity/unity/Runtime/Export/Scripting/Coroutines.cs:17)~~
#### 追記  
どうやら片方がアイテム3を使い、もう片方が何も使っていない場合これが起こる。

### ホスト側でカードの並べ替えをやっていた。以下のような警告がホスト側のコンソールで出た後、Readyボタンを押してもそれ以上動かなくなった(一度、「サーバがCheckAllPlayersReady()を実行」というログがホスト側のコンソールに出た)。
[Netcode] Trying to send ClientDisconnectedMessage to client 0 which is not in a connected state.
UnityEngine.Debug:LogWarning (object)
Unity.Netcode.NetworkLog:LogWarning (string) (at ./Library/PackageCache/com.unity.netcode.gameobjects@1.8.1/Runtime/Logging/NetworkLog.cs:28)
Unity.Netcode.NetworkMessageManager:GetMessageVersion (System.Type,ulong,bool) (at ./Library/PackageCache/com.unity.netcode.gameobjects@1.8.1/Runtime/Messaging/NetworkMessageManager.cs:545)
Unity.Netcode.NetworkMessageManager:SendMessage<Unity.Netcode.ClientDisconnectedMessage, System.Collections.Generic.List`1<ulong>> (Unity.Netcode.ClientDisconnectedMessage&,Unity.Netcode.NetworkDelivery,System.Collections.Generic.List`1<ulong>&) (at ./Library/PackageCache/com.unity.netcode.gameobjects@1.8.1/Runtime/Messaging/NetworkMessageManager.cs:622)
Unity.Netcode.NetworkConnectionManager:OnClientDisconnectFromServer (ulong) (at ./Library/PackageCache/com.unity.netcode.gameobjects@1.8.1/Runtime/Connection/NetworkConnectionManager.cs:995)
Unity.Netcode.NetworkConnectionManager:DisconnectEventHandler (ulong) (at ./Library/PackageCache/com.unity.netcode.gameobjects@1.8.1/Runtime/Connection/NetworkConnectionManager.cs:503)
Unity.Netcode.NetworkConnectionManager:HandleNetworkEvent (Unity.Netcode.NetworkEvent,ulong,System.ArraySegment`1<byte>,single) (at ./Library/PackageCache/com.unity.netcode.gameobjects@1.8.1/Runtime/Connection/NetworkConnectionManager.cs:394)
Unity.Netcode.NetworkTransport:InvokeOnTransportEvent (Unity.Netcode.NetworkEvent,ulong,System.ArraySegment`1<byte>,single) (at ./Library/PackageCache/com.unity.netcode.gameobjects@1.8.1/Runtime/Transports/NetworkTransport.cs:49)
Unity.Netcode.Transports.UTP.UnityTransport:ProcessEvent () (at ./Library/PackageCache/com.unity.netcode.gameobjects@1.8.1/Runtime/Transports/UTP/UnityTransport.cs:896)
Unity.Netcode.Transports.UTP.UnityTransport:Update () (at ./Library/PackageCache/com.unity.netcode.gameobjects@1.8.1/Runtime/Transports/UTP/UnityTransport.cs:938)

### ~~攻撃を失敗すると、次の質問でも背景が赤になった状態で質問フェーズが始まるが、詠唱をオフにしなくても普通に質問になる。~~

### ~~ホスト側でアイテム3を使用、クライアント側でアイテム5→アイテム2の順で選択し、使用。ホスト側はアイテム5を使用できたが、クライアント側は普通の質問画面になった(本来はアイテム2が使用できるはず？)~~

### 引き分けになるように両者に攻撃させた。ホスト側では引き分け画面に遷移したが、ホスト側のコンソールに以下のような警告が出て、クライアントは接続ができないままゲームが終了しなかった。
[Netcode] Trying to send ClientDisconnectedMessage to client 0 which is not in a connected state.
UnityEngine.Debug:LogWarning (object)
Unity.Netcode.NetworkLog:LogWarning (string) (at ./Library/PackageCache/com.unity.netcode.gameobjects@1.8.1/Runtime/Logging/NetworkLog.cs:28)
Unity.Netcode.NetworkMessageManager:GetMessageVersion (System.Type,ulong,bool) (at ./Library/PackageCache/com.unity.netcode.gameobjects@1.8.1/Runtime/Messaging/NetworkMessageManager.cs:545)
Unity.Netcode.NetworkMessageManager:SendMessage<Unity.Netcode.ClientDisconnectedMessage, System.Collections.Generic.List`1<ulong>> (Unity.Netcode.ClientDisconnectedMessage&,Unity.Netcode.NetworkDelivery,System.Collections.Generic.List`1<ulong>&) (at ./Library/PackageCache/com.unity.netcode.gameobjects@1.8.1/Runtime/Messaging/NetworkMessageManager.cs:622)
Unity.Netcode.NetworkConnectionManager:OnClientDisconnectFromServer (ulong) (at ./Library/PackageCache/com.unity.netcode.gameobjects@1.8.1/Runtime/Connection/NetworkConnectionManager.cs:995)
Unity.Netcode.NetworkConnectionManager:DisconnectRemoteClient (ulong) (at ./Library/PackageCache/com.unity.netcode.gameobjects@1.8.1/Runtime/Connection/NetworkConnectionManager.cs:1031)
Unity.Netcode.NetworkConnectionManager:Shutdown () (at ./Library/PackageCache/com.unity.netcode.gameobjects@1.8.1/Runtime/Connection/NetworkConnectionManager.cs:1131)
Unity.Netcode.NetworkManager:ShutdownInternal () (at ./Library/PackageCache/com.unity.netcode.gameobjects@1.8.1/Runtime/Core/NetworkManager.cs:1166)
Unity.Netcode.NetworkManager:OnDestroy () (at ./Library/PackageCache/com.unity.netcode.gameobjects@1.8.1/Runtime/Core/NetworkManager.cs:1232)