### PR TITLE
プライベートマッチ入室時に一瞬参加するの画面が表示されるバグ解消&アイテムを使わない時にアイテム3の効果テキストが表示されてしまうバグ

### DIFF
--- a/Assets/CardSortingGame/Scripts/ItemUsingManager.cs
+++ b/Assets/CardSortingGame/Scripts/ItemUsingManager.cs
@@ -170,7 +170,11 @@ public class ItemUsingManager : MonoBehaviour
 
         allUsedItem=false;
 
-        StartCoroutine(ItemUseAwaiting());
+        if(mylist.Count>0){
+            StartCoroutine(ItemUseAwaiting());
+        }else{
+            allUsedItem=true;
+        }
 
         yield return new WaitUntil(() => allUsedItem==true);
 
@@ -349,7 +353,7 @@ public class ItemUsingManager : MonoBehaviour
             }
         }
 
-        if(mygetitem==-1 || mygetitem==2){
+        if(mygetitem==2){
             networkSystem.informationManager.AddInformationText($"{itemNameDict[3]}の効果: アイテムを奪えなかった");
             Debug.Log($"{itemNameDict[3]}の効果: アイテムを奪えなかった");
         }

--- a/Assets/ChooseServerSoA/Script/ChooseServerManager.cs
+++ b/Assets/ChooseServerSoA/Script/ChooseServerManager.cs
@@ -50,20 +50,7 @@ public class ChooseServerManager : NetworkBehaviour
         return sb.ToString();
     }
 
-    async void Start(){
-        //InitializationOptions hostOptions = new InitializationOptions().SetProfile(GeneratePassword(10));
-       
-        await UnityServices.InitializeAsync();
-
-        //await UnityServices.InitializeAsync();
-       
-        AuthenticationService.Instance.SignedIn += () =>
-        {
-            Debug.Log("Signed in: " + AuthenticationService.Instance.PlayerId);
-        };
-
-        await AuthenticationService.Instance.SignInAnonymouslyAsync();
-
+    void Awake(){
         inputField = GameObject.Find("InputText").GetComponent<TMP_InputField>();
 
         waitObj = GameObject.Find("ConnectWaiting");
@@ -76,19 +63,26 @@ public class ChooseServerManager : NetworkBehaviour
             if (roomJoinButtonComponent != null)roomJoinButtonComponent.onClick.AddListener(OnRoomJoinButtonClicked);
         }
         
-        //サーバーにクライアントが接続したら実行されるメソッド
-        //注意として、ホストは「サーバーでもありクライアントでもある」という立ち位置なので
-        //ホストが接続を開始した場合もこれが実行される
-        //ホスト接続なのにIsClientがtrueになるのはこれが理由
-        //基本的に自分がホストかクライアントかを識別したい場合は
-        //IsServerを使うといいかも
-        NetworkManager.Singleton.OnClientConnectedCallback += ClientConnected;
-        
         GameObject codeTextObject = GameObject.Find("JoinCodeText");//sceneからjoincodeを表示するテキストを取得
         if (codeTextObject != null) codeText = codeTextObject.GetComponent<TextMeshProUGUI>();
         
         waitObj.SetActive(false);
         connectPanel.SetActive(false);
+    }
+
+    async void Start(){
+       
+        await UnityServices.InitializeAsync();
+       
+        AuthenticationService.Instance.SignedIn += () =>
+        {
+            Debug.Log("Signed in: " + AuthenticationService.Instance.PlayerId);
+        };
+
+        await AuthenticationService.Instance.SignInAnonymouslyAsync();
+
+
+        NetworkManager.Singleton.OnClientConnectedCallback += ClientConnected;
     }
 
     private void OnRoomJoinButtonClicked()


### PR DESCRIPTION
自分がアイテム3を使わないときに「相手のアイテムを奪えなかった」というテキストがinformationに表示されてしまう問題があったため、それの解消+マッチング画面に入室した時に一瞬参加画面が表示される不具合を修正